### PR TITLE
Improve tournament page styling and fix profile links

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,12 +4,55 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Tournament Players</title>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
   <style>
-    body { font-family: Arial, sans-serif; margin: 20px; }
-    h2 { margin-top: 1.5em; }
-    h3 { margin-top: 1em; margin-bottom: 0.3em; }
-    ul { list-style: none; padding-left: 20px; }
-    li.waitlist { color: #b00; }
+    body {
+      font-family: 'Inter', Arial, sans-serif;
+      margin: 20px;
+      background-color: #f7f9fb;
+      color: #0f172a;
+    }
+    h1 {
+      color: #3ecf8e;
+    }
+    h2 {
+      margin-top: 2em;
+      padding-bottom: 0.3em;
+      border-bottom: 1px solid #e5e7eb;
+    }
+    h3 {
+      margin-top: 1em;
+      margin-bottom: 0.3em;
+      color: #334155;
+    }
+    ul {
+      list-style: none;
+      padding-left: 0;
+    }
+    li {
+      margin: 0.25em 0;
+    }
+    a {
+      color: #2563eb;
+      text-decoration: none;
+    }
+    a:hover {
+      text-decoration: underline;
+    }
+    li.waitlist {
+      color: #dc2626;
+    }
+    .group {
+      margin-bottom: 2em;
+    }
+    .event {
+      background-color: #fff;
+      padding: 1em;
+      margin-bottom: 1em;
+      border-radius: 8px;
+      box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+    }
   </style>
 </head>
 <body>
@@ -23,30 +66,49 @@
         container.textContent = '';
         data.forEach(group => {
           const groupDiv = document.createElement('div');
+          groupDiv.className = 'group';
           const groupTitle = document.createElement('h2');
           groupTitle.textContent = group.groupTitle;
           groupDiv.appendChild(groupTitle);
           (group.events || []).forEach(evt => {
-            const evtDiv = document.createElement('div');
-            const evtTitle = document.createElement('h3');
-            evtTitle.textContent = evt.title;
-            evtDiv.appendChild(evtTitle);
+          const evtDiv = document.createElement('div');
+          evtDiv.className = 'event';
+          const evtTitle = document.createElement('h3');
+          evtTitle.textContent = evt.title;
+          evtDiv.appendChild(evtTitle);
             const list = document.createElement('ul');
             if (evt.players && evt.players.length) {
               evt.players.forEach(p => {
                 const li = document.createElement('li');
                 const playerLink = document.createElement('a');
-                playerLink.href = `https://pickleballtournaments.com/playerprofile.asp?playerid=${p.playerId}`;
+                if (p.playerSlug) {
+                  playerLink.href = `https://pickleball.com/players/${p.playerSlug}`;
+                } else {
+                  playerLink.href = `https://pickleballtournaments.com/playerprofile.asp?playerid=${p.playerId}`;
+                }
                 playerLink.target = '_blank';
                 playerLink.textContent = p.playerFullName;
                 li.appendChild(playerLink);
                 if (p.partnerId) {
                   li.appendChild(document.createTextNode(' & '));
                   const partnerLink = document.createElement('a');
-                  partnerLink.href = `https://pickleballtournaments.com/playerprofile.asp?playerid=${p.partnerId}`;
+                  if (p.partnerSlug) {
+                    partnerLink.href = `https://pickleball.com/players/${p.partnerSlug}`;
+                  } else {
+                    partnerLink.href = `https://pickleballtournaments.com/playerprofile.asp?playerid=${p.partnerId}`;
+                  }
                   partnerLink.target = '_blank';
                   partnerLink.textContent = p.partnerFullName;
                   li.appendChild(partnerLink);
+                }
+                if (p.playerDuprRating) {
+                  li.appendChild(document.createTextNode(` (DUPR: ${p.playerDuprRating}`));
+                  if (p.partnerDuprRating) {
+                    li.appendChild(document.createTextNode(`/${p.partnerDuprRating}`));
+                  }
+                  li.appendChild(document.createTextNode(')'));
+                } else if (p.partnerDuprRating) {
+                  li.appendChild(document.createTextNode(` (Partner DUPR: ${p.partnerDuprRating})`));
                 }
                 if (p.isOnWaitlist) li.classList.add('waitlist');
                 list.appendChild(li);


### PR DESCRIPTION
## Summary
- restyle tournament players page with Supabase-inspired styles
- show optional DUPR ratings if present
- link to pickleball.com player profile via `playerSlug`

## Testing
- `python -m py_compile fetch_events.py fetch_events_with_players.py`


------
https://chatgpt.com/codex/tasks/task_e_687ed5d0552c83269887ce2975bc9cf9